### PR TITLE
Fix Flyout.setZIndex()

### DIFF
--- a/src/js/WinJS/Controls/Flyout.js
+++ b/src/js/WinJS/Controls/Flyout.js
@@ -183,6 +183,7 @@ define([
                 //
 
                 setZIndex: function _LightDismissableLayer_setZIndex(zIndex) {
+                    zIndex = parseInt(zIndex);
                     this._clients.forEach(function (client, index) {
                         client.setZIndex(zIndex + index);
                     }, this);


### PR DESCRIPTION
Flyout.setZIndex() takes a string which should be parsed as an integer before adding the index to it.